### PR TITLE
SearchResult as link instead of selectable text

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -4,14 +4,17 @@ import { TextField, Box } from "@mui/material"
 interface SearchBarProps {
   query: string
   onSearch: (event: React.ChangeEvent<HTMLInputElement>) => void
+  language: Lang
 }
 
-const SearchBar: React.FC<SearchBarProps> = ({ query, onSearch }) => {
+const SearchBar: React.FC<SearchBarProps> = ({ query, onSearch, language }) => {
+  const placeholder = language === "fr" ? "Rechercher..." : "Search..."
+
   return (
     <Box sx={{ width: "100%" }}>
       <TextField
         variant="outlined"
-        placeholder="Search..."
+        placeholder={placeholder}
         value={query}
         onChange={onSearch}
         fullWidth

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Box, Chip, Typography } from "@mui/material"
-import { navigate } from "gatsby"
+import { Link } from "gatsby"
 
 interface SearchResultProps {
   results: {
@@ -67,6 +67,7 @@ const SearchResult: React.FC<SearchResultProps> = ({
 
           // Join all snippets together
           const highlightedContent = snippets.join("");
+      
 
           return (
             <Box
@@ -104,22 +105,14 @@ const SearchResult: React.FC<SearchResultProps> = ({
                   size="small"
                 />
               </Box>
-              <Typography
-                fontSize={"18px"}
-                component="div"
-                sx={{
-                  fontWeight: 600,
-                  textDecoration: "underline",
-                  cursor: "pointer",
-                  marginBottom: -2.5
-                }}
-                onClick={() => {
-                  if (result.path !== `entities`) {
-                    navigate(`/${result.path}`)
-                  }
-                }}
-              >
-                {result.title}
+              <Typography component = "div" fontSize={"18px"} sx={{ marginBottom: -2.5 }}>
+                <Link
+                  to={result.path ? `/${result.path}` : "/"}
+                  style={{ fontWeight: 600, 
+                  textDecoration: "underline" }}
+                >
+                  {result.title}
+                </Link>
               </Typography>
               <Typography
                 variant="body2"

--- a/src/templates/search.tsx
+++ b/src/templates/search.tsx
@@ -192,7 +192,7 @@ export default function PageTemplate({ pageContext }: Props) {
       <Container component="main" maxWidth="md">
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 4 }}>
           <Box sx={{ display: "flex", justifyContent: "center" }}>
-            <SearchBar query={query} onSearch={handleSearch} />
+            <SearchBar query={query} onSearch={handleSearch} language={curLang} />
           </Box>
           <Box sx={{ display: "grid", gridTemplateColumns: "1fr 3fr", gridGap: 8 }}>
             <Box sx={{ display: "flex", flexDirection: "column" }}>
@@ -237,4 +237,3 @@ export default function PageTemplate({ pageContext }: Props) {
     </Layout>
   )
 }
-


### PR DESCRIPTION
Links provided after search function were not being read as links by the screenreader,  but instead as selectable text. Fixed to read as links.